### PR TITLE
feat: broaden scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ and copy/paste:
 ```dotenv
 GITHUB_TOKEN=
 GITHUB_USERNAME=
-GITHUB_BUDDY=
+TEAM=
 ORGANIZATION=
 REPO=
+PATH_TO_WATCH=
 OPENAI_API_KEY=
 TODOIST_API_KEY=
 TODOIST_PROJECT=
@@ -60,9 +61,10 @@ GOOGLE_APP_PASSCODE=
 | --------------------- | -------------------------------------------------------------------------------------------- |
 | `GITHUB_TOKEN`        | Your GitHub token, created via `Settings > Developer Settings > PAT`                         |
 | `GITHUB_USERNAME`     | Your GitHub username.                                                                        |
-| `GITHUB_BUDDY`        | The name of a buddy on your team so you can stay informed and seem omniscient.               |
+| `TEAM`                | The name of the team you want to seem omniscient about.                                      |
 | `ORGANIZATION`        | The name of the organization you want to pull PRs from.                                      |
 | `REPO`                | The name of the repo you want to pull PRs from.                                              |
+| `PATH_TO_WATCH`       | The path to watch for changes in the PRs.                                                    |
 | `OPENAI_API_KEY`      | The OpenAI API key to invoke ChatGPT.                                                        |
 | `TODOIST_API_KEY`     | The Todoist API key to make you seem on top of 💩.                                           |
 | `TODOIST_PROJECT`     | The name of the project in Todoist you want to add tasks to.                                 |

--- a/modules/github.js
+++ b/modules/github.js
@@ -7,38 +7,46 @@ const octokit = new Octokit({
   baseUrl: "https://api.github.com",
 });
 
+const getTeamMembers = async () => {
+  let members = [];
+  const { data: teamMembers } = await octokit.teams.listMembersInOrg({
+    org: process.env.ORGANIZATION,
+    team_slug: process.env.TEAM,
+  });
+  for (const member of teamMembers) {
+    members.push(member.login);
+  }
+  return members;
+};
+
 const getPRs = async () => {
+  console.log(`🧰 Aggregating PRs...`);
   const { data: PRs } = await octokit.pulls.list({
     owner: process.env.ORGANIZATION,
     repo: process.env.REPO,
-    state: "open",
     per_page: 100,
     sort: "updated",
     direction: "desc",
   });
 
-  const myPRs = PRs.filter((pr) => {
-    const reviewers = pr.requested_reviewers.map((reviewer) => reviewer.login);
-    const isReviewer = reviewers.includes(process.env.GITHUB_USERNAME);
-    const isAuthor = pr.user.login === process.env.GITHUB_USERNAME;
-    const isBuddy = pr.user.login === process.env.GITHUB_BUDDY;
-    // to each PR, add a role property
-    if (isReviewer) {
-      pr.role = "reviewer";
+  const filteredPRs = [];
+  for (const pr of PRs) {
+    const { data: files } = await octokit.pulls.listFiles({
+      owner: process.env.ORGANIZATION,
+      repo: process.env.REPO,
+      pull_number: pr.number,
+    });
+    const changedFiles = files.map((file) => file.filename);
+    const hasChanges = changedFiles.some((file) => file.includes(process.env.PATH_TO_WATCH));
+    if (hasChanges) {
+      filteredPRs.push(pr);
     }
-    if (isAuthor) {
-      pr.role = "author";
-    }
-    if (isBuddy) {
-      pr.role = "buddy";
-    }
-    return isReviewer || isAuthor || isBuddy;
-  });
+  }
 
-  return myPRs;
+  return filteredPRs;
 };
 
-const getComments = async (PRs) => {
+const getComments = async (PRs, team) => {
   const comments = await Promise.all(
     PRs.map(async (pr) => {
       const { data: comments } = await octokit.issues.listComments({
@@ -56,11 +64,28 @@ const getComments = async (PRs) => {
       });
       comments.push(...reviewComments);
 
-      const filteredComments = comments.filter(
-        (comment) => comment.user.login !== "hasura-bot" && comment.user.login !== "github-actions[bot]"
-      );
+      // remove any reviewComments that have 0 comments in the last 24 hours
+      if (reviewComments.length === 0) {
+        return;
+      }
 
-      const commentText = filteredComments.map((comment) => {
+      const isAuthor = pr.user.login === process.env.GITHUB_USERNAME;
+
+      const isBuddy = () => {
+        if (!isAuthor) {
+          const madeComment = reviewComments.some((comment) => team.includes(comment.user.login));
+          const isReviewer = pr.requested_reviewers.some((reviewer) => team.includes(reviewer.login));
+          return madeComment || isReviewer;
+        }
+      };
+
+      const isReviewer = () => {
+        const madeComment = reviewComments.some((comment) => comment.user.login === process.env.GITHUB_USERNAME);
+        const isReviewer = pr.requested_reviewers.some((reviewer) => reviewer.login === process.env.GITHUB_USERNAME);
+        return madeComment || isReviewer;
+      };
+
+      const commentText = reviewComments.map((comment) => {
         return `${comment.body}\n\n`;
       });
 
@@ -68,17 +93,26 @@ const getComments = async (PRs) => {
         title: pr.title,
         comments: commentText,
         url: pr.html_url,
-        role: pr.role,
+        role: isAuthor ? "author" : isBuddy() ? "buddy" : isReviewer() ? "reviewer" : "unknown",
       };
     })
   );
+
+  // for any item in the array that is undefined, remove it
+  for (let i = 0; i < comments.length; i++) {
+    if (comments[i] === undefined) {
+      comments.splice(i, 1);
+      i--;
+    }
+  }
 
   return comments;
 };
 
 const runGitHub = async () => {
+  const team = await getTeamMembers();
   const PRs = await getPRs();
-  const comments = await getComments(PRs);
+  const comments = await getComments(PRs, team);
 
   console.log(
     `👀 Found ${comments.length} PRs with comments. Sending them to ChatGPT for summarization and task creation:\n`

--- a/modules/todoist.js
+++ b/modules/todoist.js
@@ -25,7 +25,7 @@ const automateTasks = async (summaries) => {
     const regex = /^[-*](.+)$/gm;
     const matches = summary.content.match(regex);
     const tasks = matches;
-    if (tasks.length > 0) {
+    if (tasks && tasks.length > 0) {
       const title = summary.title.replace(/^##/, "");
       console.log(`📋 Adding ${tasks.length} tasks for PR ${title} to Todoist...`);
       const newTask = await api.addTask({


### PR DESCRIPTION
This PR allows for a broader scope: instead of assigning a `BUDDY` env var, we're using the `teams` of an organization in GitHub. This list is returned and each username is added to an array. If the person involved in the PR is a member of the team, and not the author (user running the script), it will add this PR to the list to be analyzed by ChatGPT and return summary without action items.

We also abstract the path by which we're looking for changes; instead of hardcoding `docs`, we have a new environment variable called `PATH_TO_WATCH` where a user can enter a substring or path to check for changes.